### PR TITLE
修复程序若部署不在根目录问题导致权限拦截器判断失败问题

### DIFF
--- a/src/main/java/cn/tomoya/interceptor/PermissionInterceptor.java
+++ b/src/main/java/cn/tomoya/interceptor/PermissionInterceptor.java
@@ -27,8 +27,9 @@ public class PermissionInterceptor implements Interceptor {
 
         //处理权限部分
         Map<String, String> permissions = Permission.me.findPermissions(user.getInt("id"));
-        String path = request.getRequestURI();
-        if(permissions.containsValue(path)) {
+        //String path = request.getRequestURI();
+        String path = request.getServletPath();
+        if (permissions.containsValue(path)) {
             inv.invoke();
         } else {
             //没有权限


### PR DESCRIPTION
修复权限拦截器PermissionInterceptor判断权限使用getRequestURI，若程序部署不在根目录判断问题，改用getServletPath忽略contentPath