### PR TITLE
 Add Index on system_config.`code`

### DIFF
--- a/src/main/resources/db/migration/V1.12__add_system_config_index.sql
+++ b/src/main/resources/db/migration/V1.12__add_system_config_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `system_config_key` on `system_config`(`key`);


### PR DESCRIPTION
Adding index on table `system_config` column `code` might speed up the underlying query issued via `ISystemConfigService#selectByKey`. See #108 